### PR TITLE
Add README and docs for Jarvis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# Jarvis Voice Assistant
+
+Jarvis is a simple voice assistant written in Python. It uses speech
+recognition to listen for voice commands and `pyttsx3` to speak
+responses. The assistant can play YouTube videos, tell the current
+time, perform Google searches, read short Wikipedia summaries and tell
+jokes.
+
+## Installation
+
+1. Install Python 3.7 or higher.
+2. Install the required packages:
+   ```bash
+   pip install speechrecognition pyttsx3 pywhatkit wikipedia pyjokes
+   ```
+3. Ensure a working microphone is connected.
+
+## Usage
+
+Run the main script from the repository root:
+
+```bash
+python jarvis.py/main.py
+```
+
+Jarvis will greet you and start listening for commands. Speak
+"Jarvis" followed by one of the supported commands.
+
+## Function Reference
+
+### `talk(text)`
+Uses `pyttsx3` to speak the provided text aloud.
+
+### `take_command()`
+Listens to the microphone and returns the recognized command in
+lowercase. The word "Jarvis" is removed from the returned text.
+
+### `wishme()`
+Speaks a greeting based on the current time of day (morning,
+afternoon or evening).
+
+### `run_jarvis()`
+Parses the command returned by `take_command()` and performs one of
+the following actions:
+
+- **play** `<song>` – plays the song on YouTube
+- **time** – announces the current time
+- **search** `<query>` – performs a Google search and attempts to read a short summary
+- **who/what/where** `<topic>` – reads a brief Wikipedia summary about the topic
+- **funny/joke/sarcastic/silly/bored** – tells a random joke
+- anything else – asks the user to repeat the command
+
+## Voice Commands
+The assistant understands commands that contain the keywords listed
+above. Prefix your statement with "Jarvis" so the assistant knows to
+respond.
+
+## Documentation
+Additional documentation is available in the `docs/` directory.

--- a/docs/adding_commands.md
+++ b/docs/adding_commands.md
@@ -1,0 +1,7 @@
+# Adding New Commands
+
+1. Open `jarvis.py/main.py` in your editor.
+2. Inside the `run_jarvis()` function, add a new `elif` block checking
+   for your keyword in the `command` string.
+3. Call the desired function or write the logic to handle that command.
+4. Save the file and restart the assistant.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,8 @@
+# Troubleshooting
+
+- **Microphone not detected**: Check your system sound settings and ensure a
+  microphone is available to Python.
+- **Packages missing**: Reinstall the required packages with `pip install
+  speechrecognition pyttsx3 pywhatkit wikipedia pyjokes`.
+- **Speech not recognized**: Make sure you are in a quiet environment and your
+  internet connection is stable.


### PR DESCRIPTION
## Summary
- document Jarvis usage and commands
- add troubleshooting and command extension docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6a9ae7288331a8f4c65041c0d0b0